### PR TITLE
Allow for spaces in filenames

### DIFF
--- a/lib/processors/ffmpeg.rb
+++ b/lib/processors/ffmpeg.rb
@@ -128,7 +128,7 @@ module Paperclip
     
     def identify
       meta = {}
-      command = "ffmpeg -i #{File.expand_path(@file.path)} 2>&1"
+      command = "ffmpeg -i \"#{File.expand_path(@file.path)}\" 2>&1"
       Paperclip.log(command)
       ffmpeg = IO.popen(command)
       ffmpeg.each("\r") do |line|


### PR DESCRIPTION
Running `ffmpeg -i` fails if the uploaded file has spaces in it's name, added quotes around the filename to resolve this.
