### PR TITLE
Append WebM and Ogg Theora (ogv) format support

### DIFF
--- a/lib/paperclip_processors/ffmpeg.rb
+++ b/lib/paperclip_processors/ffmpeg.rb
@@ -129,6 +129,10 @@ module Paperclip
         @convert_options[:input][:ss] = @time
         @convert_options[:output][:vframes] = 1
         @convert_options[:output][:f] = 'image2'
+      when 'webm' # WebM
+        @convert_options[:output][:acodec] = 'libvorbis'
+        @convert_options[:output][:vcodec] = 'libvpx'
+        @convert_options[:output][:f] = 'webm'
       when 'ogv' # Ogg Theora
         @convert_options[:output][:acodec] = 'libvorbis'
         @convert_options[:output][:vcodec] = 'libtheora'


### PR DESCRIPTION
These 2 formats are specially useful with HTML5 videos. But sometimes 'ffmpeg' command doesn't use recommanded parameters.
