### PR TITLE
Bug fix for mp4 format

### DIFF
--- a/lib/paperclip_processors/ffmpeg.rb
+++ b/lib/paperclip_processors/ffmpeg.rb
@@ -137,6 +137,9 @@ module Paperclip
         @convert_options[:output][:acodec] = 'libvorbis'
         @convert_options[:output][:vcodec] = 'libtheora'
         @convert_options[:output][:f] = 'ogg'
+      when 'mp4'
+        @convert_options[:output][:acodec] = 'aac'
+        @convert_options[:output][:strict] = 'experimental'
       end
 
       Ffmpeg.log("Adding Source") if @whiny


### PR DESCRIPTION
When i want to convert a video to mp4 i have the message `encoder 'aac' is experimental and might produce bad results. Add '-strict experimental' if you want to use it` and it doesn't work.
