### PR TITLE
Replacing IO.popen with Cocaine::CommandLine

### DIFF
--- a/lib/paperclip_processors/ffmpeg.rb
+++ b/lib/paperclip_processors/ffmpeg.rb
@@ -165,10 +165,10 @@ module Paperclip
     
     def identify
       meta = {}
-      command = "ffmpeg -i \"#{File.expand_path(@file.path)}\" 2>&1"
+      command = "ffprobe \"#{File.expand_path(@file.path)}\" 2>&1"
       Paperclip.log("[ffmpeg] #{command}")
-      ffmpeg = IO.popen(command)
-      ffmpeg.each("\r") do |line|
+      ffmpeg = Cocaine::CommandLine.new(command).run
+      ffmpeg.split("\n").each do |line|
         if line =~ /(([\d\.]*)\s.?)fps,/
           meta[:fps] = $1.to_i
         end


### PR DESCRIPTION
Hey, 
  Great work on this gem!  I really enjoy working with it, with the exception of this [one](https://github.com/owahab/paperclip-ffmpeg/blob/master/lib/paperclip_processors/ffmpeg.rb#L170) line.  The `IO.popen` method is difficult to stub, and the call is chewing up system resources during tests.  Paperclip deals with this by wrapping IO calls in [Cocaine::Runners](https://github.com/thoughtbot/cocaine/tree/master/lib/cocaine/command_line/runners) which (among other things) makes it easy to switch on/off with [`Cocaine::CommandLine.fake!`](https://github.com/thoughtbot/cocaine/blob/master/spec/cocaine/command_line/runners/fake_runner_spec.rb).

Checkout the update below:
- Consistent Testing: `Cocaine::CommandLine.fake!` now stubs both paperclip and paperclip-ffmpeg
- Error Handling: the old command actually throws an error. It has been replaced with `ffprobe`.

Cheers,
Chip
